### PR TITLE
Add explicit import statement for utils

### DIFF
--- a/R/rdeque.R
+++ b/R/rdeque.R
@@ -14,6 +14,7 @@
 #' peek_front(d)
 #' peek_back(d)
 #' head() 
+#' @import utils
 
 
 


### PR DESCRIPTION
Once roxygenize is run, this will place `import(utils)` in the NAMESPACE file so that R CMD check will pass.
